### PR TITLE
Added exclude css option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,4 +19,4 @@ max_line_length = 80
 
 [*.{js,cjs}]
 indent_size = 2
-max_line_length = 80
+max_line_length = 120

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,4 +19,4 @@ max_line_length = 80
 
 [*.{js,cjs}]
 indent_size = 2
-max_line_length = 120
+max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ trim_trailing_whitespace = false
 max_line_length = 80
 
 [*.{js,cjs}]
-indent_size = 4
+indent_size = 2
 max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+max_line_length = 80
+
+[*.{js,cjs}]
+indent_size = 4
+max_line_length = 80

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "semi": false,
   "singleQuote": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "singleQuote": true
+  "semi": false,
+  "singleQuote": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "@hyva-themes/hyva-modules",
-  "version": "1.0.1",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyva-themes/hyva-modules",
-      "version": "1.0.1",
+      "version": "1.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "devDependencies": {
         "jest": "^27.5.1"
+      },
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/index.js
+++ b/src/index.js
@@ -11,17 +11,17 @@ const { cwd } = require("process");
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-    const bp = path.join(dir, "..");
-    const isBaseDir =
-        fs.existsSync(path.join(bp, "app")) &&
-        fs.existsSync(path.join(bp, "vendor"));
+  const bp = path.join(dir, "..");
+  const isBaseDir =
+    fs.existsSync(path.join(bp, "app")) &&
+    fs.existsSync(path.join(bp, "vendor"));
 
-    // FS root?
-    if (path.normalize(bp) === path.normalize(dir)) {
-        return false;
-    }
+  // FS root?
+  if (path.normalize(bp) === path.normalize(dir)) {
+    return false;
+  }
 
-    return isBaseDir ? bp : findBaseDirPath(bp);
+  return isBaseDir ? bp : findBaseDirPath(bp);
 })(cwd());
 
 const hyvaThemeJsonInModule = "app/etc/hyva-themes.json";
@@ -35,106 +35,106 @@ global.themeDirRequire = `${tailwindDir}/node_modules`;
  * Set the purge content as absolute paths on configClone in targetVersion structure
  */
 function copyPurgeContentInTargetVersion(
-    targetVersion,
-    extensionConfig,
-    configClone,
-    pathToModule
+  targetVersion,
+  extensionConfig,
+  configClone,
+  pathToModule
 ) {
-    const pathsInModule =
-        extensionConfig.purge && extensionConfig.purge.content
-            ? extensionConfig.purge.content
-            : extensionConfig.content || [];
+  const pathsInModule =
+    extensionConfig.purge && extensionConfig.purge.content
+      ? extensionConfig.purge.content
+      : extensionConfig.content || [];
 
-    if (pathsInModule.length === 0) return;
+  if (pathsInModule.length === 0) return;
 
-    // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
-    const fullPaths = pathsInModule.map((item) =>
-        path.join(pathToModule, "view/frontend/tailwind", item)
-    );
+  // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
+  const fullPaths = pathsInModule.map((item) =>
+    path.join(pathToModule, "view/frontend/tailwind", item)
+  );
 
-    // Set purge content in target version configuration structure
-    if (targetVersion === "v3") {
-        configClone.content = fullPaths;
-    } else {
-        if (!configClone.purge) configClone.purge = {};
-        configClone.purge.content = fullPaths;
-    }
+  // Set purge content in target version configuration structure
+  if (targetVersion === "v3") {
+    configClone.content = fullPaths;
+  } else {
+    if (!configClone.purge) configClone.purge = {};
+    configClone.purge.content = fullPaths;
+  }
 }
 
 /**
  * Set the extensionConfig safelist on configClone in targetVersion structure
  */
 function copySafelistInTargetVersion(
-    targetVersion,
-    extensionConfig,
-    configClone
+  targetVersion,
+  extensionConfig,
+  configClone
 ) {
-    const safelist =
-        extensionConfig.purge && extensionConfig.purge.safelist
-            ? extensionConfig.purge.safelist
-            : extensionConfig.safelist || [];
+  const safelist =
+    extensionConfig.purge && extensionConfig.purge.safelist
+      ? extensionConfig.purge.safelist
+      : extensionConfig.safelist || [];
 
-    if (safelist.length === 0) {
-        return;
-    }
+  if (safelist.length === 0) {
+    return;
+  }
 
-    // Set safelist in target version configuration structure
-    if (targetVersion === "v3") {
-        configClone.safelist = safelist;
-    } else {
-        if (!configClone.purge) configClone.purge = {};
-        configClone.purge.safelist = safelist;
-    }
+  // Set safelist in target version configuration structure
+  if (targetVersion === "v3") {
+    configClone.safelist = safelist;
+  } else {
+    if (!configClone.purge) configClone.purge = {};
+    configClone.purge.safelist = safelist;
+  }
 }
 
 function buildModuleConfigForVersion(
+  targetVersion,
+  extensionConfig,
+  modulePath
+) {
+  // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
+  // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
+  // and mutating it is a lasting side effect that affects the return value of subsequent
+  // require() calls for the same file.
+
+  // Create shallow clone of extensionConfig without content, safelist and purge
+  const { content, safelist, purge, ...configClone } = extensionConfig;
+
+  copyPurgeContentInTargetVersion(
     targetVersion,
     extensionConfig,
+    configClone,
     modulePath
-) {
-    // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
-    // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
-    // and mutating it is a lasting side effect that affects the return value of subsequent
-    // require() calls for the same file.
+  );
+  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
 
-    // Create shallow clone of extensionConfig without content, safelist and purge
-    const { content, safelist, purge, ...configClone } = extensionConfig;
+  // Currently only purge.content and purge.safelist are supported.
+  // Not supported configurations:
+  // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
+  // purge.options.*
 
-    copyPurgeContentInTargetVersion(
-        targetVersion,
-        extensionConfig,
-        configClone,
-        modulePath
-    );
-    copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
-
-    // Currently only purge.content and purge.safelist are supported.
-    // Not supported configurations:
-    // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
-    // purge.options.*
-
-    return configClone;
+  return configClone;
 }
 
 function mergeExtensionConfig(
+  targetVersion,
+  mergeTarget,
+  extensionConfig,
+  modulePath
+) {
+  const toMerge = buildModuleConfigForVersion(
     targetVersion,
-    mergeTarget,
     extensionConfig,
     modulePath
-) {
-    const toMerge = buildModuleConfigForVersion(
-        targetVersion,
-        extensionConfig,
-        modulePath
-    );
+  );
 
-    return deepmerge(mergeTarget, toMerge);
+  return deepmerge(mergeTarget, toMerge);
 }
 
 /** @type {string} */
 const hyvaThemesConfig = basePath
-    ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
-    : "";
+  ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
+  : "";
 
 /**
  * Add the full path to each path in a array
@@ -144,50 +144,50 @@ const hyvaThemesConfig = basePath
  * @returns string[] | []
  */
 function setFullPaths(paths, subPath = "") {
-    return Object.values(paths || []).map((module) =>
-        path.join(basePath, subPath ? module[subPath] : module)
-    );
+  return Object.values(paths || []).map((module) =>
+    path.join(basePath, subPath ? module[subPath] : module)
+  );
 }
 
 const hyvaModuleDirs =
-    hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, "src");
+  hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, "src");
 
 function mergeTailwindConfig(baseConfig) {
-    if (!basePath) {
-        // Since this is a new feature, we're not gonna display any error messages.
-        // console.log(
-        //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
-        //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
-        // );
-        return baseConfig;
+  if (!basePath) {
+    // Since this is a new feature, we're not gonna display any error messages.
+    // console.log(
+    //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
+    //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
+    // );
+    return baseConfig;
+  }
+
+  // Tailwind v2 uses config.purge.content, v3 uses config.content.
+  const targetTailwindVersion = baseConfig.purge ? "v2" : "v3";
+
+  let mergeConfig = {};
+
+  for (const modulePath of hyvaModuleDirs) {
+    const moduleConfigFile = path.join(
+      modulePath,
+      "view/frontend/tailwind/tailwind.config.js"
+    );
+
+    if (fs.existsSync(moduleConfigFile)) {
+      const extensionConfig = require(moduleConfigFile);
+
+      // Merge the tailwind configuration from modules
+      mergeConfig = mergeExtensionConfig(
+        targetTailwindVersion,
+        mergeConfig,
+        extensionConfig,
+        modulePath
+      );
     }
+  }
 
-    // Tailwind v2 uses config.purge.content, v3 uses config.content.
-    const targetTailwindVersion = baseConfig.purge ? "v2" : "v3";
-
-    let mergeConfig = {};
-
-    for (const modulePath of hyvaModuleDirs) {
-        const moduleConfigFile = path.join(
-            modulePath,
-            "view/frontend/tailwind/tailwind.config.js"
-        );
-
-        if (fs.existsSync(moduleConfigFile)) {
-            const extensionConfig = require(moduleConfigFile);
-
-            // Merge the tailwind configuration from modules
-            mergeConfig = mergeExtensionConfig(
-                targetTailwindVersion,
-                mergeConfig,
-                extensionConfig,
-                modulePath
-            );
-        }
-    }
-
-    // Merge theme config last so it takes precedence over all module configurations
-    return deepmerge(mergeConfig, baseConfig);
+  // Merge theme config last so it takes precedence over all module configurations
+  return deepmerge(mergeConfig, baseConfig);
 }
 
 /**
@@ -200,34 +200,32 @@ function mergeTailwindConfig(baseConfig) {
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {
-    const includeDirs =
-        (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) ||
-        hyvaModuleDirs ||
-        [];
-    const exludeDirs = setFullPaths(opts.excludeDirs);
-    const moduleDirs = includeDirs.filter(
-        (value) => !exludeDirs.includes(value)
-    );
-    const cssPath = "view/frontend/tailwind/tailwind-source.css";
+  const includeDirs =
+    (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) ||
+    hyvaModuleDirs ||
+    [];
+  const exludeDirs = setFullPaths(opts.excludeDirs);
+  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value));
+  const cssPath = "view/frontend/tailwind/tailwind-source.css";
 
-    return {
-        postcssPlugin: "hyva-postcss-in-modules",
-        Once(root, postcss) {
-            moduleDirs.forEach((moduleDir) => {
-                const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
+  return {
+    postcssPlugin: "hyva-postcss-in-modules",
+    Once(root, postcss) {
+      moduleDirs.forEach((moduleDir) => {
+        const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
 
-                if (fs.existsSync(moduleTailwindSourceCss)) {
-                    const importRule = new postcss.AtRule({
-                        name: "import",
-                        params: `"${moduleTailwindSourceCss}"`,
-                    });
+        if (fs.existsSync(moduleTailwindSourceCss)) {
+          const importRule = new postcss.AtRule({
+            name: "import",
+            params: `"${moduleTailwindSourceCss}"`,
+          });
 
-                    importRule.source = root.source;
-                    root.append(importRule);
-                }
-            });
-        },
-    };
+          importRule.source = root.source;
+          root.append(importRule);
+        }
+      });
+    },
+  };
 };
 postcssImportHyvaModules.postcss = true;
 
@@ -235,12 +233,12 @@ postcssImportHyvaModules.postcss = true;
 mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig;
 
 module.exports = {
-    // Function to merge TailwindCSS configurations from modules
-    mergeTailwindConfig,
-    // Postcss plugin to add @import nodes for all tailwind-source.css files in modules
-    postcssImportHyvaModules,
-    // Parsed contents of the app/etc/hyva-themes.json file (or false)
-    hyvaThemesConfig,
-    // Array of absolute paths to Hyvä modules
-    hyvaModuleDirs,
+  // Function to merge TailwindCSS configurations from modules
+  mergeTailwindConfig,
+  // Postcss plugin to add @import nodes for all tailwind-source.css files in modules
+  postcssImportHyvaModules,
+  // Parsed contents of the app/etc/hyva-themes.json file (or false)
+  hyvaThemesConfig,
+  // Array of absolute paths to Hyvä modules
+  hyvaModuleDirs,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,30 +4,30 @@
  * This library is distributed under the BSD-3-Clause license.
  */
 
-const deepmerge = require('deepmerge');
-const fs = require('fs');
-const path = require('path');
-const { cwd } = require('process');
+const deepmerge = require('deepmerge')
+const fs = require('fs')
+const path = require('path')
+const { cwd } = require('process')
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-  const bp = path.join(dir, '..');
-  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'));
+  const bp = path.join(dir, '..')
+  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'))
 
   // FS root?
   if (path.normalize(bp) === path.normalize(dir)) {
-    return false;
+    return false
   }
 
-  return isBaseDir ? bp : findBaseDirPath(bp);
-})(cwd());
+  return isBaseDir ? bp : findBaseDirPath(bp)
+})(cwd())
 
-const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
-const tailwindDir = cwd();
+const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json'
+const tailwindDir = cwd()
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.
 // Usage example: const colors = require(`${themeDirRequire}/tailwindcss/colors`);
-global.themeDirRequire = `${tailwindDir}/node_modules`;
+global.themeDirRequire = `${tailwindDir}/node_modules`
 
 /**
  * Set the purge content as absolute paths on configClone in targetVersion structure
@@ -36,19 +36,19 @@ function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configC
   const pathsInModule =
     extensionConfig.purge && extensionConfig.purge.content
       ? extensionConfig.purge.content
-      : extensionConfig.content || [];
+      : extensionConfig.content || []
 
-  if (pathsInModule.length === 0) return;
+  if (pathsInModule.length === 0) return
 
   // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
-  const fullPaths = pathsInModule.map((item) => path.join(pathToModule, 'view/frontend/tailwind', item));
+  const fullPaths = pathsInModule.map((item) => path.join(pathToModule, 'view/frontend/tailwind', item))
 
   // Set purge content in target version configuration structure
   if (targetVersion === 'v3') {
-    configClone.content = fullPaths;
+    configClone.content = fullPaths
   } else {
-    if (!configClone.purge) configClone.purge = {};
-    configClone.purge.content = fullPaths;
+    if (!configClone.purge) configClone.purge = {}
+    configClone.purge.content = fullPaths
   }
 }
 
@@ -59,18 +59,18 @@ function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone
   const safelist =
     extensionConfig.purge && extensionConfig.purge.safelist
       ? extensionConfig.purge.safelist
-      : extensionConfig.safelist || [];
+      : extensionConfig.safelist || []
 
   if (safelist.length === 0) {
-    return;
+    return
   }
 
   // Set safelist in target version configuration structure
   if (targetVersion === 'v3') {
-    configClone.safelist = safelist;
+    configClone.safelist = safelist
   } else {
-    if (!configClone.purge) configClone.purge = {};
-    configClone.purge.safelist = safelist;
+    if (!configClone.purge) configClone.purge = {}
+    configClone.purge.safelist = safelist
   }
 }
 
@@ -81,27 +81,27 @@ function buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath)
   // require() calls for the same file.
 
   // Create shallow clone of extensionConfig without content, safelist and purge
-  const { content, safelist, purge, ...configClone } = extensionConfig;
+  const { content, safelist, purge, ...configClone } = extensionConfig
 
-  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath);
-  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
+  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath)
+  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone)
 
   // Currently only purge.content and purge.safelist are supported.
   // Not supported configurations:
   // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
   // purge.options.*
 
-  return configClone;
+  return configClone
 }
 
 function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modulePath) {
-  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath);
+  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath)
 
-  return deepmerge(mergeTarget, toMerge);
+  return deepmerge(mergeTarget, toMerge)
 }
 
 /** @type {string} */
-const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : '';
+const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : ''
 
 /**
  * Add the full path to each path in a array
@@ -111,10 +111,10 @@ const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePat
  * @returns string[] | []
  */
 function setFullPaths(paths, subPath = '') {
-  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module));
+  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module))
 }
 
-const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');
+const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src')
 
 function mergeTailwindConfig(baseConfig) {
   if (!basePath) {
@@ -123,27 +123,27 @@ function mergeTailwindConfig(baseConfig) {
     //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
     //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
     // );
-    return baseConfig;
+    return baseConfig
   }
 
   // Tailwind v2 uses config.purge.content, v3 uses config.content.
-  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3';
+  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3'
 
-  let mergeConfig = {};
+  let mergeConfig = {}
 
   for (const modulePath of hyvaModuleDirs) {
-    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
+    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js')
 
     if (fs.existsSync(moduleConfigFile)) {
-      const extensionConfig = require(moduleConfigFile);
+      const extensionConfig = require(moduleConfigFile)
 
       // Merge the tailwind configuration from modules
-      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath);
+      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath)
     }
   }
 
   // Merge theme config last so it takes precedence over all module configurations
-  return deepmerge(mergeConfig, baseConfig);
+  return deepmerge(mergeConfig, baseConfig)
 }
 
 /**
@@ -156,34 +156,34 @@ function mergeTailwindConfig(baseConfig) {
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {
-  const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || [];
-  const exludeDirs = setFullPaths(opts.excludeDirs);
-  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value));
-  const cssPath = 'view/frontend/tailwind/tailwind-source.css';
+  const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || []
+  const exludeDirs = setFullPaths(opts.excludeDirs)
+  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value))
+  const cssPath = 'view/frontend/tailwind/tailwind-source.css'
 
   return {
     postcssPlugin: 'hyva-postcss-in-modules',
     Once(root, postcss) {
       moduleDirs.forEach((moduleDir) => {
-        const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
+        const moduleTailwindSourceCss = path.join(moduleDir, cssPath)
 
         if (fs.existsSync(moduleTailwindSourceCss)) {
           const importRule = new postcss.AtRule({
             name: 'import',
             params: `"${moduleTailwindSourceCss}"`,
-          });
+          })
 
-          importRule.source = root.source;
-          root.append(importRule);
+          importRule.source = root.source
+          root.append(importRule)
         }
-      });
+      })
     },
-  };
-};
-postcssImportHyvaModules.postcss = true;
+  }
+}
+postcssImportHyvaModules.postcss = true
 
 // For testing
-mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig;
+mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig
 
 module.exports = {
   // Function to merge TailwindCSS configurations from modules
@@ -194,4 +194,4 @@ module.exports = {
   hyvaThemesConfig,
   // Array of absolute paths to Hyvä modules
   hyvaModuleDirs,
-};
+}

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ function mergeTailwindConfig(baseConfig) {
  * @typedef {Object} PostCSSPlugin
  * @param {Object} opts - Options object.
  * @param {Array} [opts.hyvaModuleDirs=[]] - Array of directories to search for Hyva modules.
- * @param {Object} [opts.excludeDirs=[]] - Array of directories to exclude.
+ * @param {Array} [opts.excludeDirs=[]] - Array of directories to exclude.
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -131,9 +131,10 @@ function mergeExtensionConfig(
     return deepmerge(mergeTarget, toMerge);
 }
 
+/** @type {string} */
 const hyvaThemesConfig = basePath
     ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
-    : false;
+    : "";
 
 const hyvaModuleDirs =
     hyvaThemesConfig && hyvaThemesConfig.extensions

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@
 const deepmerge = require('deepmerge');
 const fs = require('fs');
 const path = require('path');
-const { cwd } = require('process');
+const {cwd} = require('process');
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
@@ -57,10 +57,9 @@ function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configC
  * Set the extensionConfig safelist on configClone in targetVersion structure
  */
 function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone) {
-  const safelist =
-    extensionConfig.purge && extensionConfig.purge.safelist
+  const safelist = extensionConfig.purge && extensionConfig.purge.safelist
       ? extensionConfig.purge.safelist
-      : extensionConfig.safelist || [];
+      : (extensionConfig.safelist || []);
 
   if (safelist.length === 0) {
     return;
@@ -76,13 +75,14 @@ function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone
 }
 
 function buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath) {
+
   // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
   // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
   // and mutating it is a lasting side effect that affects the return value of subsequent
   // require() calls for the same file.
 
   // Create shallow clone of extensionConfig without content, safelist and purge
-  const { content, safelist, purge, ...configClone } = extensionConfig;
+  const {content, safelist, purge, ...configClone} = extensionConfig;
 
   copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath);
   copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
@@ -102,7 +102,9 @@ function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modul
 }
 
 /** @type {string} */
-const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : '';
+const hyvaThemesConfig = basePath
+  ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
+  : '';
 
 /**
  * Add the full path to each path in a array
@@ -118,6 +120,7 @@ function setFullPaths(paths, subPath = '') {
 const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');
 
 function mergeTailwindConfig(baseConfig) {
+
   if (!basePath) {
     // Since this is a new feature, we're not gonna display any error messages.
     // console.log(
@@ -178,7 +181,7 @@ const postcssImportHyvaModules = (opts = {}) => {
           root.append(importRule);
         }
       });
-    },
+    }
   };
 };
 postcssImportHyvaModules.postcss = true;
@@ -194,5 +197,5 @@ module.exports = {
   // Parsed contents of the app/etc/hyva-themes.json file (or false)
   hyvaThemesConfig,
   // Array of absolute paths to Hyvä modules
-  hyvaModuleDirs,
+  hyvaModuleDirs
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,15 @@
  * This library is distributed under the BSD-3-Clause license.
  */
 
-const deepmerge = require('deepmerge');
-const fs = require('fs');
+const deepmerge = require('deepmerge')
+const fs = require('fs')
 const path = require('path');
 const {cwd} = require('process');
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-  const bp = path.join(dir, '..');
-  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'));
+  const bp = path.join(dir, '..')
+  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'))
 
   // FS root?
   if (path.normalize(bp) === path.normalize(dir)) {
@@ -20,14 +20,14 @@ const basePath = (function findBaseDirPath(dir) {
   }
 
   return isBaseDir ? bp : findBaseDirPath(bp);
-})(cwd());
+})(cwd())
 
 const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
 const tailwindDir = cwd();
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.
 // Usage example: const colors = require(`${themeDirRequire}/tailwindcss/colors`);
-global.themeDirRequire = `${tailwindDir}/node_modules`;
+global.themeDirRequire = `${tailwindDir}/node_modules`
 
 /**
  * Set the purge content as absolute paths on configClone in targetVersion structure
@@ -35,7 +35,7 @@ global.themeDirRequire = `${tailwindDir}/node_modules`;
 function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, pathToModule) {
   const pathsInModule = extensionConfig.purge && extensionConfig.purge.content
     ? extensionConfig.purge.content
-    : extensionConfig.content || [];
+    : (extensionConfig.content || []);
 
   if (pathsInModule.length === 0) {
     return;
@@ -58,8 +58,8 @@ function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configC
  */
 function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone) {
   const safelist = extensionConfig.purge && extensionConfig.purge.safelist
-      ? extensionConfig.purge.safelist
-      : (extensionConfig.safelist || []);
+    ? extensionConfig.purge.safelist
+    : (extensionConfig.safelist || []);
 
   if (safelist.length === 0) {
     return;
@@ -139,15 +139,15 @@ function mergeTailwindConfig(baseConfig) {
     const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
 
     if (fs.existsSync(moduleConfigFile)) {
-      const extensionConfig = require(moduleConfigFile);
+      const extensionConfig = require(moduleConfigFile)
 
       // Merge the tailwind configuration from modules
-      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath);
+      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath)
     }
   }
 
   // Merge theme config last so it takes precedence over all module configurations
-  return deepmerge(mergeConfig, baseConfig);
+  return deepmerge(mergeConfig, baseConfig)
 }
 
 /**
@@ -172,10 +172,7 @@ const postcssImportHyvaModules = (opts = {}) => {
         const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
 
         if (fs.existsSync(moduleTailwindSourceCss)) {
-          const importRule = new postcss.AtRule({
-            name: 'import',
-            params: `"${moduleTailwindSourceCss}"`,
-          });
+          const importRule = new postcss.AtRule({name: 'import', params: `"${moduleTailwindSourceCss}"`});
 
           importRule.source = root.source;
           root.append(importRule);

--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,15 @@
  * This library is distributed under the BSD-3-Clause license.
  */
 
-const deepmerge = require("deepmerge");
-const fs = require("fs");
-const path = require("path");
-const { cwd } = require("process");
+const deepmerge = require('deepmerge');
+const fs = require('fs');
+const path = require('path');
+const { cwd } = require('process');
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-  const bp = path.join(dir, "..");
-  const isBaseDir =
-    fs.existsSync(path.join(bp, "app")) &&
-    fs.existsSync(path.join(bp, "vendor"));
+  const bp = path.join(dir, '..');
+  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'));
 
   // FS root?
   if (path.normalize(bp) === path.normalize(dir)) {
@@ -24,7 +22,7 @@ const basePath = (function findBaseDirPath(dir) {
   return isBaseDir ? bp : findBaseDirPath(bp);
 })(cwd());
 
-const hyvaThemeJsonInModule = "app/etc/hyva-themes.json";
+const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
 const tailwindDir = cwd();
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.
@@ -34,12 +32,7 @@ global.themeDirRequire = `${tailwindDir}/node_modules`;
 /**
  * Set the purge content as absolute paths on configClone in targetVersion structure
  */
-function copyPurgeContentInTargetVersion(
-  targetVersion,
-  extensionConfig,
-  configClone,
-  pathToModule
-) {
+function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, pathToModule) {
   const pathsInModule =
     extensionConfig.purge && extensionConfig.purge.content
       ? extensionConfig.purge.content
@@ -48,12 +41,10 @@ function copyPurgeContentInTargetVersion(
   if (pathsInModule.length === 0) return;
 
   // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
-  const fullPaths = pathsInModule.map((item) =>
-    path.join(pathToModule, "view/frontend/tailwind", item)
-  );
+  const fullPaths = pathsInModule.map((item) => path.join(pathToModule, 'view/frontend/tailwind', item));
 
   // Set purge content in target version configuration structure
-  if (targetVersion === "v3") {
+  if (targetVersion === 'v3') {
     configClone.content = fullPaths;
   } else {
     if (!configClone.purge) configClone.purge = {};
@@ -64,11 +55,7 @@ function copyPurgeContentInTargetVersion(
 /**
  * Set the extensionConfig safelist on configClone in targetVersion structure
  */
-function copySafelistInTargetVersion(
-  targetVersion,
-  extensionConfig,
-  configClone
-) {
+function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone) {
   const safelist =
     extensionConfig.purge && extensionConfig.purge.safelist
       ? extensionConfig.purge.safelist
@@ -79,7 +66,7 @@ function copySafelistInTargetVersion(
   }
 
   // Set safelist in target version configuration structure
-  if (targetVersion === "v3") {
+  if (targetVersion === 'v3') {
     configClone.safelist = safelist;
   } else {
     if (!configClone.purge) configClone.purge = {};
@@ -87,11 +74,7 @@ function copySafelistInTargetVersion(
   }
 }
 
-function buildModuleConfigForVersion(
-  targetVersion,
-  extensionConfig,
-  modulePath
-) {
+function buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath) {
   // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
   // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
   // and mutating it is a lasting side effect that affects the return value of subsequent
@@ -100,12 +83,7 @@ function buildModuleConfigForVersion(
   // Create shallow clone of extensionConfig without content, safelist and purge
   const { content, safelist, purge, ...configClone } = extensionConfig;
 
-  copyPurgeContentInTargetVersion(
-    targetVersion,
-    extensionConfig,
-    configClone,
-    modulePath
-  );
+  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath);
   copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
 
   // Currently only purge.content and purge.safelist are supported.
@@ -116,25 +94,14 @@ function buildModuleConfigForVersion(
   return configClone;
 }
 
-function mergeExtensionConfig(
-  targetVersion,
-  mergeTarget,
-  extensionConfig,
-  modulePath
-) {
-  const toMerge = buildModuleConfigForVersion(
-    targetVersion,
-    extensionConfig,
-    modulePath
-  );
+function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modulePath) {
+  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath);
 
   return deepmerge(mergeTarget, toMerge);
 }
 
 /** @type {string} */
-const hyvaThemesConfig = basePath
-  ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
-  : "";
+const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : '';
 
 /**
  * Add the full path to each path in a array
@@ -143,14 +110,11 @@ const hyvaThemesConfig = basePath
  * @param {string} subPath - subpath from paths to use
  * @returns string[] | []
  */
-function setFullPaths(paths, subPath = "") {
-  return Object.values(paths || []).map((module) =>
-    path.join(basePath, subPath ? module[subPath] : module)
-  );
+function setFullPaths(paths, subPath = '') {
+  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module));
 }
 
-const hyvaModuleDirs =
-  hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, "src");
+const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');
 
 function mergeTailwindConfig(baseConfig) {
   if (!basePath) {
@@ -163,26 +127,18 @@ function mergeTailwindConfig(baseConfig) {
   }
 
   // Tailwind v2 uses config.purge.content, v3 uses config.content.
-  const targetTailwindVersion = baseConfig.purge ? "v2" : "v3";
+  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3';
 
   let mergeConfig = {};
 
   for (const modulePath of hyvaModuleDirs) {
-    const moduleConfigFile = path.join(
-      modulePath,
-      "view/frontend/tailwind/tailwind.config.js"
-    );
+    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
 
     if (fs.existsSync(moduleConfigFile)) {
       const extensionConfig = require(moduleConfigFile);
 
       // Merge the tailwind configuration from modules
-      mergeConfig = mergeExtensionConfig(
-        targetTailwindVersion,
-        mergeConfig,
-        extensionConfig,
-        modulePath
-      );
+      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath);
     }
   }
 
@@ -200,23 +156,20 @@ function mergeTailwindConfig(baseConfig) {
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {
-  const includeDirs =
-    (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) ||
-    hyvaModuleDirs ||
-    [];
+  const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || [];
   const exludeDirs = setFullPaths(opts.excludeDirs);
   const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value));
-  const cssPath = "view/frontend/tailwind/tailwind-source.css";
+  const cssPath = 'view/frontend/tailwind/tailwind-source.css';
 
   return {
-    postcssPlugin: "hyva-postcss-in-modules",
+    postcssPlugin: 'hyva-postcss-in-modules',
     Once(root, postcss) {
       moduleDirs.forEach((moduleDir) => {
         const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
 
         if (fs.existsSync(moduleTailwindSourceCss)) {
           const importRule = new postcss.AtRule({
-            name: "import",
+            name: 'import',
             params: `"${moduleTailwindSourceCss}"`,
           });
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,51 +4,52 @@
  * This library is distributed under the BSD-3-Clause license.
  */
 
-const deepmerge = require('deepmerge')
-const fs = require('fs')
-const path = require('path')
-const { cwd } = require('process')
+const deepmerge = require('deepmerge');
+const fs = require('fs');
+const path = require('path');
+const { cwd } = require('process');
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-  const bp = path.join(dir, '..')
-  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'))
+  const bp = path.join(dir, '..');
+  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'));
 
   // FS root?
   if (path.normalize(bp) === path.normalize(dir)) {
-    return false
+    return false;
   }
 
-  return isBaseDir ? bp : findBaseDirPath(bp)
-})(cwd())
+  return isBaseDir ? bp : findBaseDirPath(bp);
+})(cwd());
 
-const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json'
-const tailwindDir = cwd()
+const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
+const tailwindDir = cwd();
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.
 // Usage example: const colors = require(`${themeDirRequire}/tailwindcss/colors`);
-global.themeDirRequire = `${tailwindDir}/node_modules`
+global.themeDirRequire = `${tailwindDir}/node_modules`;
 
 /**
  * Set the purge content as absolute paths on configClone in targetVersion structure
  */
 function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, pathToModule) {
-  const pathsInModule =
-    extensionConfig.purge && extensionConfig.purge.content
-      ? extensionConfig.purge.content
-      : extensionConfig.content || []
+  const pathsInModule = extensionConfig.purge && extensionConfig.purge.content
+    ? extensionConfig.purge.content
+    : extensionConfig.content || [];
 
-  if (pathsInModule.length === 0) return
+  if (pathsInModule.length === 0) {
+    return;
+  }
 
   // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
-  const fullPaths = pathsInModule.map((item) => path.join(pathToModule, 'view/frontend/tailwind', item))
+  const fullPaths = pathsInModule.map(item => path.join(pathToModule, 'view/frontend/tailwind', item));
 
   // Set purge content in target version configuration structure
   if (targetVersion === 'v3') {
-    configClone.content = fullPaths
+    configClone.content = fullPaths;
   } else {
-    if (!configClone.purge) configClone.purge = {}
-    configClone.purge.content = fullPaths
+    if (!configClone.purge) configClone.purge = {};
+    configClone.purge.content = fullPaths;
   }
 }
 
@@ -59,18 +60,18 @@ function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone
   const safelist =
     extensionConfig.purge && extensionConfig.purge.safelist
       ? extensionConfig.purge.safelist
-      : extensionConfig.safelist || []
+      : extensionConfig.safelist || [];
 
   if (safelist.length === 0) {
-    return
+    return;
   }
 
   // Set safelist in target version configuration structure
   if (targetVersion === 'v3') {
-    configClone.safelist = safelist
+    configClone.safelist = safelist;
   } else {
-    if (!configClone.purge) configClone.purge = {}
-    configClone.purge.safelist = safelist
+    if (!configClone.purge) configClone.purge = {};
+    configClone.purge.safelist = safelist;
   }
 }
 
@@ -81,27 +82,27 @@ function buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath)
   // require() calls for the same file.
 
   // Create shallow clone of extensionConfig without content, safelist and purge
-  const { content, safelist, purge, ...configClone } = extensionConfig
+  const { content, safelist, purge, ...configClone } = extensionConfig;
 
-  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath)
-  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone)
+  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath);
+  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
 
   // Currently only purge.content and purge.safelist are supported.
   // Not supported configurations:
   // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
   // purge.options.*
 
-  return configClone
+  return configClone;
 }
 
 function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modulePath) {
-  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath)
+  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath);
 
-  return deepmerge(mergeTarget, toMerge)
+  return deepmerge(mergeTarget, toMerge);
 }
 
 /** @type {string} */
-const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : ''
+const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule))) : '';
 
 /**
  * Add the full path to each path in a array
@@ -111,10 +112,10 @@ const hyvaThemesConfig = basePath ? JSON.parse(fs.readFileSync(path.join(basePat
  * @returns string[] | []
  */
 function setFullPaths(paths, subPath = '') {
-  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module))
+  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module));
 }
 
-const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src')
+const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');
 
 function mergeTailwindConfig(baseConfig) {
   if (!basePath) {
@@ -123,27 +124,27 @@ function mergeTailwindConfig(baseConfig) {
     //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
     //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
     // );
-    return baseConfig
+    return baseConfig;
   }
 
   // Tailwind v2 uses config.purge.content, v3 uses config.content.
-  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3'
+  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3';
 
-  let mergeConfig = {}
+  let mergeConfig = {};
 
   for (const modulePath of hyvaModuleDirs) {
-    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js')
+    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
 
     if (fs.existsSync(moduleConfigFile)) {
-      const extensionConfig = require(moduleConfigFile)
+      const extensionConfig = require(moduleConfigFile);
 
       // Merge the tailwind configuration from modules
-      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath)
+      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath);
     }
   }
 
   // Merge theme config last so it takes precedence over all module configurations
-  return deepmerge(mergeConfig, baseConfig)
+  return deepmerge(mergeConfig, baseConfig);
 }
 
 /**
@@ -156,34 +157,34 @@ function mergeTailwindConfig(baseConfig) {
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {
-  const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || []
-  const exludeDirs = setFullPaths(opts.excludeDirs)
-  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value))
-  const cssPath = 'view/frontend/tailwind/tailwind-source.css'
+  const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || [];
+  const exludeDirs = setFullPaths(opts.excludeDirs);
+  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value));
+  const cssPath = 'view/frontend/tailwind/tailwind-source.css';
 
   return {
     postcssPlugin: 'hyva-postcss-in-modules',
     Once(root, postcss) {
       moduleDirs.forEach((moduleDir) => {
-        const moduleTailwindSourceCss = path.join(moduleDir, cssPath)
+        const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
 
         if (fs.existsSync(moduleTailwindSourceCss)) {
           const importRule = new postcss.AtRule({
             name: 'import',
             params: `"${moduleTailwindSourceCss}"`,
-          })
+          });
 
-          importRule.source = root.source
-          root.append(importRule)
+          importRule.source = root.source;
+          root.append(importRule);
         }
-      })
+      });
     },
-  }
-}
-postcssImportHyvaModules.postcss = true
+  };
+};
+postcssImportHyvaModules.postcss = true;
 
 // For testing
-mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig
+mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig;
 
 module.exports = {
   // Function to merge TailwindCSS configurations from modules
@@ -194,4 +195,4 @@ module.exports = {
   hyvaThemesConfig,
   // Array of absolute paths to Hyvä modules
   hyvaModuleDirs,
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,170 +4,217 @@
  * This library is distributed under the BSD-3-Clause license.
  */
 
-const deepmerge = require('deepmerge')
-const fs = require('fs')
-const path = require('path');
-const {cwd} = require('process');
+const deepmerge = require("deepmerge");
+const fs = require("fs");
+const path = require("path");
+const { cwd } = require("process");
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
-  const bp = path.join(dir, '..')
-  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'))
+    const bp = path.join(dir, "..");
+    const isBaseDir =
+        fs.existsSync(path.join(bp, "app")) &&
+        fs.existsSync(path.join(bp, "vendor"));
 
-  // FS root?
-  if (path.normalize(bp) === path.normalize(dir)) {
-    return false;
-  }
+    // FS root?
+    if (path.normalize(bp) === path.normalize(dir)) {
+        return false;
+    }
 
-  return isBaseDir ? bp : findBaseDirPath(bp);
-})(cwd())
+    return isBaseDir ? bp : findBaseDirPath(bp);
+})(cwd());
 
-const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
-
+const hyvaThemeJsonInModule = "app/etc/hyva-themes.json";
 const tailwindDir = cwd();
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.
 // Usage example: const colors = require(`${themeDirRequire}/tailwindcss/colors`);
-global.themeDirRequire = `${tailwindDir}/node_modules`
+global.themeDirRequire = `${tailwindDir}/node_modules`;
 
 /**
  * Set the purge content as absolute paths on configClone in targetVersion structure
  */
-function copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, pathToModule) {
-  const pathsInModule = extensionConfig.purge && extensionConfig.purge.content
-    ? extensionConfig.purge.content
-    : (extensionConfig.content || []);
+function copyPurgeContentInTargetVersion(
+    targetVersion,
+    extensionConfig,
+    configClone,
+    pathToModule
+) {
+    const pathsInModule =
+        extensionConfig.purge && extensionConfig.purge.content
+            ? extensionConfig.purge.content
+            : extensionConfig.content || [];
 
-  if (pathsInModule.length === 0) {
-    return;
-  }
+    if (pathsInModule.length === 0) return;
 
-  // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
-  const fullPaths = pathsInModule.map(item => path.join(pathToModule, 'view/frontend/tailwind', item));
+    // Prepend each content config record from module with the path to the module view/frontend/tailwind directory
+    const fullPaths = pathsInModule.map((item) =>
+        path.join(pathToModule, "view/frontend/tailwind", item)
+    );
 
-  // Set purge content in target version configuration structure
-  if (targetVersion === 'v3') {
-    configClone.content = fullPaths;
-  } else {
-    if (!configClone.purge) configClone.purge = {};
-    configClone.purge.content = fullPaths;
-  }
+    // Set purge content in target version configuration structure
+    if (targetVersion === "v3") {
+        configClone.content = fullPaths;
+    } else {
+        if (!configClone.purge) configClone.purge = {};
+        configClone.purge.content = fullPaths;
+    }
 }
 
 /**
  * Set the extensionConfig safelist on configClone in targetVersion structure
  */
-function copySafelistInTargetVersion(targetVersion, extensionConfig, configClone) {
-  const safelist = extensionConfig.purge && extensionConfig.purge.safelist
-    ? extensionConfig.purge.safelist
-    : (extensionConfig.safelist || []);
+function copySafelistInTargetVersion(
+    targetVersion,
+    extensionConfig,
+    configClone
+) {
+    const safelist =
+        extensionConfig.purge && extensionConfig.purge.safelist
+            ? extensionConfig.purge.safelist
+            : extensionConfig.safelist || [];
 
-  if (safelist.length === 0) {
-    return;
-  }
+    if (safelist.length === 0) {
+        return;
+    }
 
-  // Set safelist in target version configuration structure
-  if (targetVersion === 'v3') {
-    configClone.safelist = safelist;
-  } else {
-    if (!configClone.purge) configClone.purge = {};
-    configClone.purge.safelist = safelist;
-  }
+    // Set safelist in target version configuration structure
+    if (targetVersion === "v3") {
+        configClone.safelist = safelist;
+    } else {
+        if (!configClone.purge) configClone.purge = {};
+        configClone.purge.safelist = safelist;
+    }
 }
 
-function buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath) {
+function buildModuleConfigForVersion(
+    targetVersion,
+    extensionConfig,
+    modulePath
+) {
+    // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
+    // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
+    // and mutating it is a lasting side effect that affects the return value of subsequent
+    // require() calls for the same file.
 
-  // Use a clone of the config object to avoid deepmerge concatenating the arrays multiple times.
-  // The reason is require(moduleConfigFile) always returns the same instance on multiple calls,
-  // and mutating it is a lasting side effect that affects the return value of subsequent
-  // require() calls for the same file.
+    // Create shallow clone of extensionConfig without content, safelist and purge
+    const { content, safelist, purge, ...configClone } = extensionConfig;
 
-  // Create shallow clone of extensionConfig without content, safelist and purge
-  const {content, safelist, purge, ...configClone} = extensionConfig;
+    copyPurgeContentInTargetVersion(
+        targetVersion,
+        extensionConfig,
+        configClone,
+        modulePath
+    );
+    copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
 
-  copyPurgeContentInTargetVersion(targetVersion, extensionConfig, configClone, modulePath);
-  copySafelistInTargetVersion(targetVersion, extensionConfig, configClone);
+    // Currently only purge.content and purge.safelist are supported.
+    // Not supported configurations:
+    // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
+    // purge.options.*
 
-  // Currently only purge.content and purge.safelist are supported.
-  // Not supported configurations:
-  // purge.enabled, purge.transform, purge.extract, purge.preserveHtmlElements, purge.layers, purge.mode
-  // purge.options.*
-
-  return configClone;
+    return configClone;
 }
 
-function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modulePath) {
-  const toMerge = buildModuleConfigForVersion(targetVersion, extensionConfig, modulePath);
+function mergeExtensionConfig(
+    targetVersion,
+    mergeTarget,
+    extensionConfig,
+    modulePath
+) {
+    const toMerge = buildModuleConfigForVersion(
+        targetVersion,
+        extensionConfig,
+        modulePath
+    );
 
-  return deepmerge(mergeTarget, toMerge);
+    return deepmerge(mergeTarget, toMerge);
 }
 
 const hyvaThemesConfig = basePath
-  ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
-  : false;
+    ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
+    : false;
 
-const hyvaModuleDirs = hyvaThemesConfig && hyvaThemesConfig.extensions
-  ? Object.values(hyvaThemesConfig.extensions || []).map(module => path.join(basePath, module.src))
-  : [];
+const hyvaModuleDirs =
+    hyvaThemesConfig && hyvaThemesConfig.extensions
+        ? Object.values(hyvaThemesConfig.extensions || []).map((module) =>
+              path.join(basePath, module.src)
+          )
+        : [];
 
 function mergeTailwindConfig(baseConfig) {
-
-  if (!basePath) {
-    // Since this is a new feature, we're not gonna display any error messages.
-    // console.log(
-    //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
-    //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
-    // );
-    return baseConfig;
-  }
-
-  // Tailwind v2 uses config.purge.content, v3 uses config.content.
-  const targetTailwindVersion = baseConfig.purge ? 'v2' : 'v3';
-
-  let mergeConfig = {};
-
-  for (const modulePath of hyvaModuleDirs) {
-    const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
-
-    if (fs.existsSync(moduleConfigFile)) {
-      const extensionConfig = require(moduleConfigFile)
-
-      // Merge the tailwind configuration from modules
-      mergeConfig = mergeExtensionConfig(targetTailwindVersion, mergeConfig, extensionConfig, modulePath)
+    if (!basePath) {
+        // Since this is a new feature, we're not gonna display any error messages.
+        // console.log(
+        //     '\x1b[36mwarn\x1b[0m - File \'hyva-themes.json\' not found.',
+        //     'Run \x1b[36mbin/magento hyva:config:generate\x1b[0m and try again.'
+        // );
+        return baseConfig;
     }
-  }
 
-  // Merge theme config last so it takes precedence over all module configurations
-  return deepmerge(mergeConfig, baseConfig)
+    // Tailwind v2 uses config.purge.content, v3 uses config.content.
+    const targetTailwindVersion = baseConfig.purge ? "v2" : "v3";
+
+    let mergeConfig = {};
+
+    for (const modulePath of hyvaModuleDirs) {
+        const moduleConfigFile = path.join(
+            modulePath,
+            "view/frontend/tailwind/tailwind.config.js"
+        );
+
+        if (fs.existsSync(moduleConfigFile)) {
+            const extensionConfig = require(moduleConfigFile);
+
+            // Merge the tailwind configuration from modules
+            mergeConfig = mergeExtensionConfig(
+                targetTailwindVersion,
+                mergeConfig,
+                extensionConfig,
+                modulePath
+            );
+        }
+    }
+
+    // Merge theme config last so it takes precedence over all module configurations
+    return deepmerge(mergeConfig, baseConfig);
 }
 
-const postcssImportHyvaModules = ((opts = {}) => {
-  return {
-    postcssPlugin: 'hyva-postcss-in-modules',
-    Once(root, postcss) {
-      (opts.hyvaModuleDirs || hyvaModuleDirs || []).forEach(moduleDir => {
-        const moduleTailwindSourceCss = path.join(moduleDir, 'view/frontend/tailwind/tailwind-source.css');
-        if (fs.existsSync(moduleTailwindSourceCss)) {
-          const importRule = new postcss.AtRule({name: 'import', params: `"${moduleTailwindSourceCss}"`});
-          importRule.source = root.source;
-          root.append(importRule);
-        }
-      });
-    }
-  }
-});
+const postcssImportHyvaModules = (opts = {}) => {
+    return {
+        postcssPlugin: "hyva-postcss-in-modules",
+        Once(root, postcss) {
+            (opts.hyvaModuleDirs || hyvaModuleDirs || []).forEach(
+                (moduleDir) => {
+                    const moduleTailwindSourceCss = path.join(
+                        moduleDir,
+                        "view/frontend/tailwind/tailwind-source.css"
+                    );
+                    if (fs.existsSync(moduleTailwindSourceCss)) {
+                        const importRule = new postcss.AtRule({
+                            name: "import",
+                            params: `"${moduleTailwindSourceCss}"`,
+                        });
+                        importRule.source = root.source;
+                        root.append(importRule);
+                    }
+                }
+            );
+        },
+    };
+};
 postcssImportHyvaModules.postcss = true;
 
 // For testing
 mergeTailwindConfig.mergeExtensionConfig = mergeExtensionConfig;
 
 module.exports = {
-  // Function to merge TailwindCSS configurations from modules
-  mergeTailwindConfig,
-  // Postcss plugin to add @import nodes for all tailwind-source.css files in modules
-  postcssImportHyvaModules,
-  // Parsed contents of the app/etc/hyva-themes.json file (or false)
-  hyvaThemesConfig,
-  // Array of absolute paths to Hyvä modules
-  hyvaModuleDirs
-}
+    // Function to merge TailwindCSS configurations from modules
+    mergeTailwindConfig,
+    // Postcss plugin to add @import nodes for all tailwind-source.css files in modules
+    postcssImportHyvaModules,
+    // Parsed contents of the app/etc/hyva-themes.json file (or false)
+    hyvaThemesConfig,
+    // Array of absolute paths to Hyvä modules
+    hyvaModuleDirs,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -190,15 +190,14 @@ const postcssImportHyvaModules = (opts = {}) => {
     const moduleDirs = includeDirs.filter(
         (value) => !exludeDirs.includes(value)
     );
+    const cssPath = "view/frontend/tailwind/tailwind-source.css";
 
     return {
         postcssPlugin: "hyva-postcss-in-modules",
         Once(root, postcss) {
-                    const moduleTailwindSourceCss = path.join(
-                        moduleDir,
-                        "view/frontend/tailwind/tailwind-source.css"
-                    );
             moduleDirs.forEach((moduleDir) => {
+                const moduleTailwindSourceCss = path.join(moduleDir, cssPath);
+
                 if (fs.existsSync(moduleTailwindSourceCss)) {
                     const importRule = new postcss.AtRule({
                         name: "import",

--- a/src/index.js
+++ b/src/index.js
@@ -102,10 +102,10 @@ function mergeExtensionConfig(targetVersion, mergeTarget, extensionConfig, modul
   return deepmerge(mergeTarget, toMerge);
 }
 
-/** @type {string} */
+/** @type {Object|boolean} */
 const hyvaThemesConfig = basePath
   ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
-  : '';
+  : false;
 
 /**
  * Add the full path to each path in a array

--- a/src/index.js
+++ b/src/index.js
@@ -162,8 +162,8 @@ function mergeTailwindConfig(baseConfig) {
  */
 const postcssImportHyvaModules = (opts = {}) => {
   const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || [];
-  const exludeDirs = setFullPaths(opts.excludeDirs);
-  const moduleDirs = includeDirs.filter((value) => !exludeDirs.includes(value));
+  const excludeDirs = setFullPaths(opts.excludeDirs);
+  const moduleDirs = includeDirs.filter((value) => !excludeDirs.includes(value));
   const cssPath = 'view/frontend/tailwind/tailwind-source.css';
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -185,8 +185,8 @@ function mergeTailwindConfig(baseConfig) {
  *
  * @typedef {Object} PostCSSPlugin
  * @param {Object} opts - Options object.
- * @param {Array} [opts.hyvaModuleDirs=[]] - Array of directories to search for Hyva modules.
- * @param {Array} [opts.excludeDirs=[]] - Array of directories to exclude.
+ * @param {Array} [opts.hyvaModuleDirs=[]] - Directories to search for Hyva modules.
+ * @param {Array} [opts.excludeDirs=[]] - Directories to exclude.
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -180,6 +180,15 @@ function mergeTailwindConfig(baseConfig) {
     return deepmerge(mergeConfig, baseConfig);
 }
 
+/**
+ * PostCSS plugin to import Tailwind CSS files from Hyva modules.
+ *
+ * @typedef {Object} PostCSSPlugin
+ * @param {Object} opts - Options object.
+ * @param {Array} [opts.hyvaModuleDirs=[]] - Array of directories to search for Hyva modules.
+ * @param {Object} [opts.excludeDirs=[]] - Array of directories to exclude.
+ * @returns {Object} PostCSS plugin object.
+ */
 const postcssImportHyvaModules = (opts = {}) => {
     const includeDirs = opts.hyvaModuleDirs || hyvaModuleDirs || [];
     const exludeDirs = opts.excludeDirs

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const basePath = (function findBaseDirPath(dir) {
 })(cwd())
 
 const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';
+
 const tailwindDir = cwd();
 
 // Global variable with prefix to use inside extensions tailwind.config.js file to require installed node modules.

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ function mergeTailwindConfig(baseConfig) {
  */
 const postcssImportHyvaModules = (opts = {}) => {
   const includeDirs = (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) || hyvaModuleDirs || [];
-  const excludeDirs = setFullPaths(opts.excludeDirs);
+  const excludeDirs = (opts.excludeDirs && setFullPaths(opts.excludeDirs)) || [];
   const moduleDirs = includeDirs.filter((value) => !excludeDirs.includes(value));
   const cssPath = 'view/frontend/tailwind/tailwind-source.css';
 

--- a/src/index.js
+++ b/src/index.js
@@ -195,8 +195,8 @@ function mergeTailwindConfig(baseConfig) {
  *
  * @typedef {Object} PostCSSPlugin
  * @param {Object} opts - Options object.
- * @param {Array} [opts.hyvaModuleDirs=[]] - Directories to search for Hyva modules.
- * @param {Array} [opts.excludeDirs=[]] - Directories to exclude.
+ * @param {string[]} [opts.hyvaModuleDirs=[]] - Directories to search for Hyva modules.
+ * @param {string[]} [opts.excludeDirs=[]] - Directories to exclude.
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -111,11 +111,11 @@ const hyvaThemesConfig = basePath
  * Add the full path to each path in a array
  *
  * @param {string[]} paths - to add the basePath to
- * @param {string} subPath - subpath from paths to use
+ * @param {string} key - key from paths to use
  * @returns string[] | []
  */
-function setFullPaths(paths, subPath = '') {
-  return Object.values(paths || []).map((module) => path.join(basePath, subPath ? module[subPath] : module));
+function setFullPaths(paths, key = '') {
+  return Object.values(paths || []).map((module) => path.join(basePath, key ? module[key] : module));
 }
 
 const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');

--- a/src/index.js
+++ b/src/index.js
@@ -181,10 +181,10 @@ function mergeTailwindConfig(baseConfig) {
 }
 
 const postcssImportHyvaModules = (opts = {}) => {
+    const includeDirs = opts.hyvaModuleDirs || hyvaModuleDirs || [];
     return {
         postcssPlugin: "hyva-postcss-in-modules",
         Once(root, postcss) {
-            (opts.hyvaModuleDirs || hyvaModuleDirs || []).forEach(
                 (moduleDir) => {
                     const moduleTailwindSourceCss = path.join(
                         moduleDir,

--- a/src/index.js
+++ b/src/index.js
@@ -182,24 +182,33 @@ function mergeTailwindConfig(baseConfig) {
 
 const postcssImportHyvaModules = (opts = {}) => {
     const includeDirs = opts.hyvaModuleDirs || hyvaModuleDirs || [];
+    const exludeDirs = opts.excludeDirs
+        ? Object.values(opts.excludeDirs).map((module) =>
+              path.join(basePath, module)
+          )
+        : [];
+    const moduleDirs = includeDirs.filter(
+        (value) => !exludeDirs.includes(value)
+    );
+
     return {
         postcssPlugin: "hyva-postcss-in-modules",
         Once(root, postcss) {
-                (moduleDir) => {
                     const moduleTailwindSourceCss = path.join(
                         moduleDir,
                         "view/frontend/tailwind/tailwind-source.css"
                     );
-                    if (fs.existsSync(moduleTailwindSourceCss)) {
-                        const importRule = new postcss.AtRule({
-                            name: "import",
-                            params: `"${moduleTailwindSourceCss}"`,
-                        });
-                        importRule.source = root.source;
-                        root.append(importRule);
-                    }
+            moduleDirs.forEach((moduleDir) => {
+                if (fs.existsSync(moduleTailwindSourceCss)) {
+                    const importRule = new postcss.AtRule({
+                        name: "import",
+                        params: `"${moduleTailwindSourceCss}"`,
+                    });
+
+                    importRule.source = root.source;
+                    root.append(importRule);
                 }
-            );
+            });
         },
     };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -136,12 +136,21 @@ const hyvaThemesConfig = basePath
     ? JSON.parse(fs.readFileSync(path.join(basePath, hyvaThemeJsonInModule)))
     : "";
 
+/**
+ * Add the full path to each path in a array
+ *
+ * @param {string[]} paths - to add the basePath to
+ * @param {string} subPath - subpath from paths to use
+ * @returns string[] | []
+ */
+function setFullPaths(paths, subPath = "") {
+    return Object.values(paths || []).map((module) =>
+        path.join(basePath, subPath ? module[subPath] : module)
+    );
+}
+
 const hyvaModuleDirs =
-    hyvaThemesConfig && hyvaThemesConfig.extensions
-        ? Object.values(hyvaThemesConfig.extensions || []).map((module) =>
-              path.join(basePath, module.src)
-          )
-        : [];
+    hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, "src");
 
 function mergeTailwindConfig(baseConfig) {
     if (!basePath) {
@@ -191,12 +200,11 @@ function mergeTailwindConfig(baseConfig) {
  * @returns {Object} PostCSS plugin object.
  */
 const postcssImportHyvaModules = (opts = {}) => {
-    const includeDirs = opts.hyvaModuleDirs || hyvaModuleDirs || [];
-    const exludeDirs = opts.excludeDirs
-        ? Object.values(opts.excludeDirs).map((module) =>
-              path.join(basePath, module)
-          )
-        : [];
+    const includeDirs =
+        (opts.hyvaModuleDirs && setFullPaths(opts.hyvaModuleDirs)) ||
+        hyvaModuleDirs ||
+        [];
+    const exludeDirs = setFullPaths(opts.excludeDirs);
     const moduleDirs = includeDirs.filter(
         (value) => !exludeDirs.includes(value)
     );

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ const postcssImportHyvaModules = (opts = {}) => {
         }
       });
     }
-  };
+  }
 };
 postcssImportHyvaModules.postcss = true;
 
@@ -198,4 +198,4 @@ module.exports = {
   hyvaThemesConfig,
   // Array of absolute paths to Hyvä modules
   hyvaModuleDirs
-};
+}


### PR DESCRIPTION
This pull request not only adds the requested feature of excluding CSS files, found in #2 ,
but also incorporates the improvements made in PR #5. Therefore, it should be merged after that PR.

The new feature extends the options object to include another option called `excludeDirs`. This enables users to opt out of certain CSS files from specific modules in favor of their own solutions.

The `excludeDirs` option can be passed in the same way as the `hyvaModuleDirs` option in the `postcss.config.js` file.

To test this new option, please install this version and add the following to the `postcss.config.js` file to exclude the `hyva-theme/checkout-main` CSS file.

```js
const { postcssImportHyvaModules } = require("@hyva-themes/hyva-modules");

module.exports = {
    plugins: [
        postcssImportHyvaModules({
            excludeDirs: ["vendor/hyva-themes/magento2-hyva-checkout/src"],
        }),
        require("postcss-import"),
        require("tailwindcss/nesting"),
        require("tailwindcss"),
        require("autoprefixer"),
    ],
};
```

_The full path is used, same as found in the `app/etc/hyva-themes.json`, without the escapes._

Run `npm run build` to see the results.

This new feature provides users with the ability to opt out of the CSS styling performed through the tailwind-source.css file, without the need to opt out of the purge config merging. This is particularly useful when the tailwind-source.css file conflicts with your own theme's version of the button styling. Instead of writing a convoluted override, you can simply take control of the situation with this option.