### PR TITLE
ix Dynamically determining basePath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,15 @@ const {cwd} = require('process');
 
 // Determine Magento base dir by searching for parent dir containing an app/ and a vendor/ folder
 const basePath = (function findBaseDirPath(dir) {
+  const isBaseDir = fs.existsSync(path.join(dir, 'app')) && fs.existsSync(path.join(dir, 'vendor'))
   const bp = path.join(dir, '..')
-  const isBaseDir = fs.existsSync(path.join(bp, 'app')) && fs.existsSync(path.join(bp, 'vendor'))
 
   // FS root?
   if (path.normalize(bp) === path.normalize(dir)) {
     return false;
   }
 
-  return isBaseDir ? bp : findBaseDirPath(bp);
+  return isBaseDir ? dir : findBaseDirPath(bp);
 })(cwd())
 
 const hyvaThemeJsonInModule = 'app/etc/hyva-themes.json';


### PR DESCRIPTION
When the tailwind.config.js is in the project root. It can't properly determine the basePath, since it doesn't scan the current directory for /app and /vendor, but rather goes straight to scanning it's parent folder.

Fixes #7