### PR TITLE
Support module paths outside of Magento root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,13 @@ const hyvaThemesConfig = basePath
  * @returns string[] | []
  */
 function setFullPaths(paths, key = '') {
-  return Object.values(paths || []).map((module) => path.join(basePath, key ? module[key] : module));
+    return Object.values(paths || []).map((module) => {
+    const modulePath = key ? module[key] : module;
+    if (fs.existsSync(modulePath)) {
+      return modulePath;
+    }
+    return path.join(basePath, modulePath)
+  });
 }
 
 const hyvaModuleDirs = hyvaThemesConfig && setFullPaths(hyvaThemesConfig.extensions, 'src');


### PR DESCRIPTION
In my Magento environment, I'm using local composer repositories that are outside of the Magento root. In other words, if Magento lives in `/var/www/html`, a Magento module could actually be living in `/data/extensions/`. Unfortunately, this JS util is expecting the module path to be part of the Magento root, and because of that, it fails to detect a custom Tailwind file. This PR adds support for module paths outside of Magento, simply by seeing if the delivered (absolute) path exists.