### PR TITLE
Add notice on inclusion of Tailwind file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ function mergeTailwindConfig(baseConfig) {
     const moduleConfigFile = path.join(modulePath, 'view/frontend/tailwind/tailwind.config.js');
 
     if (fs.existsSync(moduleConfigFile)) {
+      console.log('Including ' + moduleConfigFile);
       const extensionConfig = require(moduleConfigFile)
 
       // Merge the tailwind configuration from modules


### PR DESCRIPTION
When using quite a number of Hyva extensions, each with their own Tailwind file, it is nice to know which file is included, and what order. This PR adds a little notice to help people with that.