### PR TITLE
align .gitignore detection with Tailwind v4 recursive behavior

### DIFF
--- a/bin/generate-sources.js
+++ b/bin/generate-sources.js
@@ -37,26 +37,52 @@ const filteredModules =
 const includedModules = hyvaConfig.tailwind?.include ?? [];
 const hyvaModules = [...filteredModules, ...includedModules];
 
+// Walk upward from the Magento root until we hit the repo root (or filesystem
+// root) and warn when a lone "*" in .gitignore would block Tailwind content
+// scanning in v4.
 (async () => {
     try {
-        const gitignorePath = path.join(basePath, ".gitignore");
-        if (existsSync(gitignorePath)) {
-            const gitignore = await fs.readFile(gitignorePath, "utf-8");
-            if (gitignore.split("\n").some((line) => line.trim() === "*")) {
-                consoleWarn(
-                    [
-                        "",
-                        'Warning: Your root .gitignore file contains a single "*" character, which is an allow-list pattern.',
-                        "This pattern is not supported by Tailwind CSS v4 for content scanning.",
-                        "Tailwind will not be able to find your template files, resulting in missing CSS.",
-                        "Please use a traditional exclude-list in your .gitignore file.",
-                        "",
-                    ].join("\n")
-                );
+        for (
+            let currentDir = basePath;
+            ;
+            currentDir = path.dirname(currentDir)
+        ) {
+            const gitignorePath = path.join(currentDir, ".gitignore");
+            const gitPath = path.join(currentDir, ".git");
+
+            if (existsSync(gitignorePath)) {
+                const gitignore = await fs.readFile(gitignorePath, "utf-8");
+                const hasAllowListStar = gitignore
+                    .split("\n")
+                    .some((line) => line.trim() === "*");
+
+                if (hasAllowListStar) {
+                    consoleWarn(
+                        [
+                            "",
+                            `Warning: The .gitignore file at "${gitignorePath}" contains a single "*" character, which is an allow-list pattern.`,
+                            "This pattern is not supported by Tailwind CSS v4 for content scanning.",
+                            "Tailwind will not be able to find your template files, resulting in missing CSS.",
+                            "Please use a traditional exclude-list in your .gitignore file.",
+                            "",
+                        ].join("\n")
+                    );
+                    break;
+                }
+            }
+
+            if (existsSync(gitPath)) {
+                break;
+            }
+
+            const parentDir = path.dirname(currentDir);
+            if (parentDir === currentDir) {
+                // Reached filesystem root without finding .git.
+                break;
             }
         }
     } catch (error) {
-        // Fail silently.
+        // Fail silently; the warning is best-effort and must not stop generation.
     }
 })();
 


### PR DESCRIPTION
In some hosting environments or Monorepo architectures, the Git repository root often sits above the Magento installation directory. Consequently, the relevant `.gitignore` file affects the project but resides outside the standard Magento file structure.

The previous validation logic was limited to the current working directory, failing to detect blocking configurations in parent directories. This resulted in silent failures where Tailwind CSS v4 source detection would be blocked by a root-level `*` rule. Please see tailwindcss v4 logic: https://github.com/tailwindlabs/tailwindcss/blob/819881994347fc492d3da351f45bb2e4538b8034/crates/oxide/src/scanner/mod.rs#L664

### Directory Structure & Traversal Logic
The updated logic initiates at the execution path and traverses upwards. It does not blindly stop at the Magento root; instead, it continues until it detects the `.git` directory, ensuring the true repository root is evaluated.

**Example Scenario: Nested Magento Installation**
Consider a scenario where the Magento project is a subdirectory of a larger infrastructure repository:

```text
infrastructure-root/
├── .git/
├── .gitignore
└── magento-project/
    └── app/
        └── design/
            └── frontend/
                └── Hyva/
                    └── default/
                        └── web/
                            └── tailwindcss/